### PR TITLE
JSON化とPOST api の変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,10 @@ POSTも実装しました。
 
 メモリ上に以下のデータがあるので、これをGETRequestで取得できます。
 
-### メタデータ
+### 本のデータ
 ```
-{"id": 1, "title": "cool book", "ISBN": 100},
-{"id": 2, "title": "awesome book", "ISBN": 200}
-```
-
-### 本の詳細データ
-```
-{"ISBN": 100, "title": "cool book", "story": "A super hero beats monsters."},
-{"ISBN": 200, "title": "awesome book", "story": "A text book of go langage."}
+{"id": 1, "title": "cool book", "description": "A super hero beats monsters.", "ISBN": 100},
+{"id": 2, "title": "awesome book", "description": "A text book of go langage.", "ISBN": 200}
 ```
 
 # Requirement
@@ -45,15 +39,9 @@ $ docker-compose up --build
 
 
 ## POSTフォーマット
-メタ情報が、
-`{"title": "~", "ISBN": xxx}`
-
-詳細情報が、
-`{"ISBN": xxx, "title": "~", "story": "~"}`
+`{"title":"~","ISBN":xxx,"description":"~"}`
 
 で登録できます。
-
-先に対応するISBNを持つメタ情報が登録されていないと、詳細情報は登録できません。
 
 # Example
 
@@ -74,7 +62,7 @@ ISBNでの取得は、
 例えば、
 `$ curl {ホストのIPアドレス}:8080/books/100`
 でISBN = 100の本の詳細、
-`{"ISBN": 100, "title": "cool book", "story": "A super hero beats monsters."}`
+`{"ISBN": 100, "title": "cool book", "description": "A super hero beats monsters."}`
 が取得できる。
 
 `$ curl {ホストのIPアドレス}:8080/books/300`
@@ -84,22 +72,14 @@ ISBNでの取得は、
 
 ## POSTリクエスト
 
-POSTリクエストは、メタ情報が、
-`$ curl -X POST -H "Content-Type: application/json" -d '{"ISBN":, ...}' {ホストのIPアドレス}:8080/books`
+POSTリクエストは、
+`$ curl -X POST -H "Content-Type: application/json" -d '{"title":"~", ...}' {ホストのIPアドレス}:8080/books`
 で行えます。
-
-詳細情報が、
-`$ curl -X POST -H "Content-Type: application/json" -d '{"ISBN":, ...}' {ホストのIPアドレス}:8080/books/:ISBN`
-で行えます。
-
-対応するISBNのメタ情報が未登録の場合、
-`Book Meta Data Not Found`
-が返ります。
-
-urlとデータのISBNが不一致の場合、
-`ISBN is inconsistent`
-が返ります。
 
 もしJSONがフォーマット通りでない場合、
 `Invalid Post Format`
+が返ります。
+
+もし詳細情報がすでに存在している場合、
+`Book info already exists`
 が返ります。

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -10,15 +10,23 @@ import (
 
 type (
 
-	// 本のメタ情報用構造体
-	metaInfo struct {
+	// 本情報用構造体
+	bookInfo struct {
+		ID    int    `json:"id"`
+		Title string `json:"title"`
+		Story string `json:"story"`
+		ISBN  int    `json:"ISBN"`
+	}
+
+	// 本メタ情報用構造体
+	bookMetaInfo struct {
 		ID    int    `json:"id"`
 		Title string `json:"title"`
 		ISBN  int    `json:"ISBN"`
 	}
 
-	// 本の詳細情報用構造体
-	bookProfile struct {
+	// 本詳細情報用構造体
+	bookProfileInfo struct {
 		ISBN  int    `json:"ISBN"`
 		Title string `json:"title"`
 		Story string `json:"story"`
@@ -26,40 +34,24 @@ type (
 )
 
 var (
-	tmpMeta1 = metaInfo{
+	tmpData1 = bookInfo{
 		ID:    1,
 		Title: "cool book",
+		Story: "A super hero beats monsters.",
 		ISBN:  100,
 	}
 
-	tmpMeta2 = metaInfo{
+	tmpData2 = bookInfo{
 		ID:    2,
 		Title: "awesome book",
-		ISBN:  200,
-	}
-
-	// 本のメタ情報格納用配列　（そのうちデータベースに移行）
-	metaInfoDataBase = []metaInfo{
-		tmpMeta1,
-		tmpMeta2,
-	}
-
-	tmpProfile1 = bookProfile{
-		ISBN:  100,
-		Title: "cool book",
-		Story: "A super hero beats monsters.",
-	}
-
-	tmpProfile2 = bookProfile{
-		ISBN:  200,
-		Title: "awesome book",
 		Story: "A text book of go langage.",
+		ISBN:  200,
 	}
 
-	// 本の詳細情報格納用配列　（そのうちデータベースに移行）
-	bookProfileDataBase = []bookProfile{
-		tmpProfile1,
-		tmpProfile2,
+	// 本情報格納用配列　（そのうちデータベースに移行）
+	bookDataBase = []bookInfo{
+		tmpData1,
+		tmpData2,
 	}
 )
 
@@ -67,22 +59,28 @@ var (
 func GetBookMetaInfoAll(c echo.Context) error { //c をいじって Request, Responseを色々する
 
 	// message にinfoを順次ぶち込んでいく
-	message := "["
+	message := ""
 
-	for i, m := range metaInfoDataBase {
+	for i, m := range bookDataBase {
+		tmp := bookMetaInfo{
+			ID:    m.ID,
+			Title: m.Title,
+			ISBN:  m.ISBN,
+		}
+
 		//構造体をjsonのバイナリに変換
-		jsonBinary, _ := json.Marshal(m)
+		jsonBinary, _ := json.Marshal(tmp)
 
 		message += string(jsonBinary)
 
-		if i != len(metaInfoDataBase)-1 {
+		if i != len(bookDataBase)-1 {
 			message += ","
 		}
 	}
 
-	message += "]"
+	//message += "]"
 
-	return c.String(http.StatusOK, message)
+	return c.JSON(http.StatusOK, message)
 }
 
 //GetBookProfile 本情報１件取得
@@ -94,12 +92,19 @@ func GetBookProfile(c echo.Context) error {
 		return c.String(http.StatusBadRequest, "ISBN must be an integer")
 	}
 
-	for _, b := range bookProfileDataBase {
+	for _, b := range bookDataBase {
 		if isbn == b.ISBN {
-			//構造体をjsonのバイナリに変換
-			jsonBinary, _ := json.Marshal(b)
+			tmp := bookProfileInfo{
+				Title: b.Title,
+				ISBN:  b.ISBN,
+				Story: b.Story,
+			}
+			/*
+				//構造体をjsonのバイナリに変換
+				jsonBinary, _ := json.Marshal(b)
+			*/
 
-			return c.String(http.StatusOK, string(jsonBinary))
+			return c.JSON(http.StatusOK, tmp)
 		}
 	}
 
@@ -107,87 +112,38 @@ func GetBookProfile(c echo.Context) error {
 
 }
 
-// PostMetaInfo メタ情報Post用メソッド
-func PostMetaInfo(c echo.Context) error {
-	meta := new(metaInfo)
+// PostBookInfo メタ情報Post用メソッド
+func PostBookInfo(c echo.Context) error {
+	info := new(bookInfo)
 
 	// request bodyをmetaInfo構造体にバインド
-	if err := c.Bind(meta); err != nil {
+	if err := c.Bind(info); err != nil {
 		return c.String(http.StatusBadRequest, "Invalid Post Format")
 	}
 
 	// ポストメッセージのフォーマットが不正
-	if meta.Title == "" || meta.ISBN == 0 {
+	if info.Title == "" || info.ISBN == 0 || info.Story == "" {
 		return c.String(http.StatusBadRequest, "Invalid Post Format")
 	}
 
 	// メタ情報が既に登録ずみならBad request
-	for _, m := range metaInfoDataBase {
-		if meta.ISBN == m.ISBN {
+	for _, b := range bookDataBase {
+		if info.ISBN == b.ISBN {
 			return c.String(http.StatusBadRequest, "Meta info already exists")
 		}
 	}
 
-	id := metaInfoDataBase[len(metaInfoDataBase)-1].ID + 1
+	id := bookDataBase[len(bookDataBase)-1].ID + 1
 
-	meta.ID = id
+	info.ID = id
 
-	//構造体をjsonのバイナリに変換
-	jsonBinary, _ := json.Marshal(meta)
+	/*
+		//構造体をjsonのバイナリに変換
+		jsonBinary, _ := json.Marshal(meta)
 
-	message := string(jsonBinary)
-	metaInfoDataBase = append(metaInfoDataBase, *meta)
+		message := string(jsonBinary)
+	*/
+	bookDataBase = append(bookDataBase, *info)
 
-	return c.String(http.StatusOK, message)
-}
-
-// PostBookProfile 詳細情報Post用メソッド
-func PostBookProfile(c echo.Context) error {
-	// urlのisbn取得
-	isbn, err := strconv.Atoi(c.Param("ISBN"))
-	if err != nil {
-		// ISBNがintでなければBadRequestを返す
-		return c.String(http.StatusBadRequest, "ISBN must be an integer")
-	}
-
-	profile := new(bookProfile)
-
-	// request bodyをbookProfile構造体にバインド
-	if err := c.Bind(profile); err != nil {
-		return c.String(http.StatusBadRequest, "Invalid Post Format")
-	}
-
-	// ポストメッセージのフォーマットが不正
-	if profile.Title == "" || profile.Story == "" {
-		return c.String(http.StatusBadRequest, "Invalid Post Format")
-	}
-
-	// urlとpostデータのISBNが一致していることを確認
-	if isbn != profile.ISBN {
-		return c.String(http.StatusBadRequest, "ISBN is inconsistent")
-	}
-
-	// 詳細情報が既に登録ずみならBad request
-	for _, p := range bookProfileDataBase {
-		if profile.ISBN == p.ISBN {
-			return c.String(http.StatusBadRequest, "Book profile already exists")
-		}
-	}
-
-	// メタ情報が登録されていることを確認
-	for _, b := range metaInfoDataBase {
-		if isbn == b.ISBN {
-
-			//構造体をjsonのバイナリに変換
-			jsonBinary, _ := json.Marshal(profile)
-
-			message := string(jsonBinary)
-			bookProfileDataBase = append(bookProfileDataBase, *profile)
-
-			return c.String(http.StatusOK, message)
-		}
-	}
-
-	return c.String(http.StatusNotFound, "Book Meta Data Not Found")
-
+	return c.JSON(http.StatusOK, info)
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -10,42 +9,42 @@ import (
 
 type (
 
-	// 本情報用構造体
+	// 本情報用構造体（POST用）
 	bookInfo struct {
-		ID    int    `json:"id"`
-		Title string `json:"title"`
-		Story string `json:"story"`
-		ISBN  int    `json:"ISBN"`
+		ID          int    `json:"id"`
+		Title       string `json:"title"`
+		Description string `json:"description"`
+		ISBN        int    `json:"ISBN"`
 	}
 
-	// 本メタ情報用構造体
+	// 本メタ情報用構造体（GET用）
 	bookMetaInfo struct {
 		ID    int    `json:"id"`
 		Title string `json:"title"`
 		ISBN  int    `json:"ISBN"`
 	}
 
-	// 本詳細情報用構造体
+	// 本詳細情報用構造体（GET用）
 	bookProfileInfo struct {
-		ISBN  int    `json:"ISBN"`
-		Title string `json:"title"`
-		Story string `json:"story"`
+		ISBN        int    `json:"ISBN"`
+		Title       string `json:"title"`
+		Description string `json:"description"`
 	}
 )
 
 var (
 	tmpData1 = bookInfo{
-		ID:    1,
-		Title: "cool book",
-		Story: "A super hero beats monsters.",
-		ISBN:  100,
+		ID:          1,
+		Title:       "cool book",
+		Description: "A super hero beats monsters.",
+		ISBN:        100,
 	}
 
 	tmpData2 = bookInfo{
-		ID:    2,
-		Title: "awesome book",
-		Story: "A text book of go langage.",
-		ISBN:  200,
+		ID:          2,
+		Title:       "awesome book",
+		Description: "A text book of go langage.",
+		ISBN:        200,
 	}
 
 	// 本情報格納用配列　（そのうちデータベースに移行）
@@ -58,27 +57,18 @@ var (
 // GetBookMetaInfoAll 本情報全取得
 func GetBookMetaInfoAll(c echo.Context) error { //c をいじって Request, Responseを色々する
 
-	// message にinfoを順次ぶち込んでいく
-	message := ""
+	// message（bookMetaInfo配列） にメタ情報を順次格納していく
+	message := []bookMetaInfo{}
 
-	for i, m := range bookDataBase {
+	for _, m := range bookDataBase {
 		tmp := bookMetaInfo{
 			ID:    m.ID,
 			Title: m.Title,
 			ISBN:  m.ISBN,
 		}
 
-		//構造体をjsonのバイナリに変換
-		jsonBinary, _ := json.Marshal(tmp)
-
-		message += string(jsonBinary)
-
-		if i != len(bookDataBase)-1 {
-			message += ","
-		}
+		message = append(message, tmp)
 	}
-
-	//message += "]"
 
 	return c.JSON(http.StatusOK, message)
 }
@@ -95,15 +85,10 @@ func GetBookProfile(c echo.Context) error {
 	for _, b := range bookDataBase {
 		if isbn == b.ISBN {
 			tmp := bookProfileInfo{
-				Title: b.Title,
-				ISBN:  b.ISBN,
-				Story: b.Story,
+				Title:       b.Title,
+				ISBN:        b.ISBN,
+				Description: b.Description,
 			}
-			/*
-				//構造体をjsonのバイナリに変換
-				jsonBinary, _ := json.Marshal(b)
-			*/
-
 			return c.JSON(http.StatusOK, tmp)
 		}
 	}
@@ -122,14 +107,14 @@ func PostBookInfo(c echo.Context) error {
 	}
 
 	// ポストメッセージのフォーマットが不正
-	if info.Title == "" || info.ISBN == 0 || info.Story == "" {
+	if info.Title == "" || info.ISBN == 0 || info.Description == "" {
 		return c.String(http.StatusBadRequest, "Invalid Post Format")
 	}
 
 	// メタ情報が既に登録ずみならBad request
 	for _, b := range bookDataBase {
 		if info.ISBN == b.ISBN {
-			return c.String(http.StatusBadRequest, "Meta info already exists")
+			return c.String(http.StatusBadRequest, "Book info already exists")
 		}
 	}
 
@@ -137,12 +122,6 @@ func PostBookInfo(c echo.Context) error {
 
 	info.ID = id
 
-	/*
-		//構造体をjsonのバイナリに変換
-		jsonBinary, _ := json.Marshal(meta)
-
-		message := string(jsonBinary)
-	*/
 	bookDataBase = append(bookDataBase, *info)
 
 	return c.JSON(http.StatusOK, info)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -34,6 +34,9 @@ var (
 	// ダメなPOST
 	invalidPostData = `{"foo":"bar"}`
 
+	// やる気のないPOST
+	badPostData = `hello world`
+
 	// JSON ヘッダ
 	jsonHeader = `application/json; charset=UTF-8`
 
@@ -184,6 +187,24 @@ func TestPostDataWithInvalidArgument(t *testing.T) {
 	// Setup
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(invalidPostData))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/books")
+
+	// Assertions
+	if assert.NoError(t, PostBookInfo(c)) {
+		res := rec.Result()
+		assert.Equal(t, plainTextHeader, res.Header.Get("Content-Type"))
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		assert.Equal(t, invalidFormat, rec.Body.String())
+	}
+}
+
+func TestPostDataWithBadArgument(t *testing.T) {
+	// Setup
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(badPostData))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)

--- a/main.go
+++ b/main.go
@@ -12,8 +12,7 @@ func main() {
 	// ルーティング
 	e.GET("/books", handler.GetBookMetaInfoAll)
 	e.GET("/books/:ISBN", handler.GetBookProfile)
-	e.POST("/books", handler.PostMetaInfo)
-	e.POST("/books/:ISBN", handler.PostBookProfile)
+	e.POST("/books", handler.PostBookInfo)
 
 	e.Start(":8080")
 


### PR DESCRIPTION
Close #8 
Close #11 

ヘッダを`application/json; charset=UTF-8`にしました。
POSTリクエストを、本情報をメタと詳細一括で送信できるようにしました。
