### PR TITLE
mysql-clientを存在するものに更新

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,8 @@ jobs:
       - run:
           name: Install MySQL CLI; Import dummy data
           command: |
-            sudo apt-get install mysql-client
+            sudo apt update
+            sudo apt-get install default-mysql-client
             mysql --version
             mysql -h 127.0.0.1 -u root -proot < ./database/sql/setup.sql
       - run:


### PR DESCRIPTION
Close #36

変更点
- debianパッケージからmysql-clientがなくなっててciが通らなくなってたため、新しいclientパッケージに変更しました。
