### PR TITLE
ISBNのオーバーフロー防止

### DIFF
--- a/database/sql/setup.sql
+++ b/database/sql/setup.sql
@@ -1,7 +1,7 @@
 CREATE DATABASE bookbasket;
 
 CREATE TABLE bookbasket.bookInfo(
-    ISBN INT NOT NULL PRIMARY KEY,
+    ISBN BIGINT UNSIGNED NOT NULL PRIMARY KEY,
     title VARCHAR(50),
     description TEXT
 );
@@ -22,7 +22,7 @@ CREATE TABLE bookbasket.threadMetaInfo(
     id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
     userID INT,
     title VARCHAR(50),
-    ISBN INT 
+    ISBN BIGINT UNSIGNED
 );
 
 INSERT INTO bookbasket.threadMetaInfo (userID, title, ISBN) VALUES(

--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -12,20 +12,20 @@ type (
 
 	// 本情報用構造体（POST、データ保存用）
 	BookInfo struct {
-		ISBN        int    `json:"ISBN" db:"ISBN"`
+		ISBN        uint64    `json:"ISBN" db:"ISBN"`
 		Title       string `json:"title" db:"title"`
 		Description string `json:"description" db:"description"`
 	}
 
 	// 本メタ情報用構造体（GET用）
 	BookMetaInfo struct {
-		ISBN  int    `json:"ISBN" db:"ISBN"`
+		ISBN  uint64    `json:"ISBN" db:"ISBN"`
 		Title string `json:"title" db:"title"`
 	}
 
 	// 本詳細情報用構造体（GET用）
 	BookProfileInfo struct {
-		ISBN        int    `json:"ISBN" db:"ISBN"`
+		ISBN        uint64    `json:"ISBN" db:"ISBN"`
 		Title       string `json:"title" db:"title"`
 		Description string `json:"description" db:"description"`
 	}
@@ -35,7 +35,7 @@ type (
 		ID     int    `json:"id" db:"id"`
 		UserID int    `json:"userID" db:"userID"`
 		Title  string `json:"title" db:"title"`
-		ISBN   int    `json:"ISBN" db:"ISBN"`
+		ISBN   uint64    `json:"ISBN" db:"ISBN"`
 	}
 
 	// スレッド発言情報
@@ -220,7 +220,7 @@ func PostThreadTitle(c echo.Context) error {
 	}
 
 	// スレッドのISBN設定
-	info.ISBN = isbn
+	info.ISBN = uint64(isbn)
 
 	// 一件挿入用クエリ
 	_, err = db.Exec("INSERT INTO threadMetaInfo (userID, title, ISBN) VALUES(?,?,?)", info.UserID, info.Title, info.ISBN)


### PR DESCRIPTION
Close #44

変更点
- ISBNのデータ型がintで13桁はオーバーフローしてしまうので、GoとMysqlを変更しました。
