### PR TITLE
静的ページを配置

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,13 +5,10 @@ services:
     depends_on:
       - "db"
     ports:
-      - "8080:8080"
+      - "80:8080"
     entrypoint: ./wait-for-it.sh db:3306 -- ./server
   db:
     build: ./database
     container_name: my_db
     ports:
       - "3306:3306"
-    
-    
-  

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,6 +21,6 @@ RUN apk add --update --no-cache bash
 
 COPY --from=build /server .
 COPY ./wait-for-it.sh .
+COPY ./web ./web
 
 EXPOSE 8080
-

--- a/server/main.go
+++ b/server/main.go
@@ -21,6 +21,9 @@ func main() {
 	// Echoのインスタンス作る
 	e := echo.New()
 
+	// 静的ファイルのルーティング
+	e.Static("/", "web")
+
 	// ルーティング
 	e.GET("/books", handler.GetBookMetaInfoAll)
 	e.GET("/books/:ISBN", handler.GetBookProfile)


### PR DESCRIPTION
Close #43

変更点
- ドキュメントルートアクセス時に静的htmlページを返す機能を追加
- server/web以下にflutter buildしたファイルを配置してください。
